### PR TITLE
Do not specify OpenCV version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
 )
 
-find_package(OpenCV 3 REQUIRED)
+find_package(OpenCV REQUIRED)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)


### PR DESCRIPTION
Hello!
Thank you for the great work. It works perfectly except for a small issue with the CMake configuration, if the installed OpenCV version is different than 3 it would not compile on our setup. The (simple) fix is to just remove the OpenCV version requirement.

Based on our tests, it works on both OpenCV 3 and 4.